### PR TITLE
fix: consolidate duplicated code, added tests

### DIFF
--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -26,12 +26,14 @@ use Pressbooks\HtmlParser;
 use Pressbooks\Modules\Export\Export;
 use Pressbooks\Modules\Export\ExportGenerator;
 use Pressbooks\Modules\Export\ExportHelpers;
+use Pressbooks\Modules\Export\Traits\HandleContributors;
 use Pressbooks\Sanitize;
 use Pressbooks\Taxonomy;
 use Pressbooks\Utility\PercentageYield;
 
 class Epub extends ExportGenerator {
 	use ExportHelpers;
+	use HandleContributors;
 
 	const VERSION = '3.2';
 
@@ -841,7 +843,7 @@ class Epub extends ExportGenerator {
 
 		if ( ! \Pressbooks\Media\is_valid_media( $tmp_file, $filename ) ) {
 			$this->fetchedMediaCache[ $url ] = '';
-			fclose( $GLOBALS[ $resource_key ] ); // @codingStandardsIgnoreLine
+            fclose( $GLOBALS[ $resource_key ] ); // @codingStandardsIgnoreLine
 			return ''; // Not a valid media type
 		}
 
@@ -852,7 +854,7 @@ class Epub extends ExportGenerator {
 			$filename = wp_unique_filename( $fullpath, $filename );
 			copy( $tmp_file, "$fullpath/$filename" );
 		}
-		fclose( $GLOBALS[ $resource_key ] ); // @codingStandardsIgnoreLine
+        fclose( $GLOBALS[ $resource_key ] ); // @codingStandardsIgnoreLine
 
 		$this->fetchedMediaCache[ $url ] = $filename;
 
@@ -1342,48 +1344,18 @@ class Epub extends ExportGenerator {
 				]
 			);
 		} else {
-			$authors = null;
-			$contributors = null;
-			$editors = null;
-			$translators = null;
-			$illustrators = null;
-
-			if ( isset( $metadata['pb_authors'] ) && ! empty( $metadata['pb_authors'] ) ) {
-				$authors = is_array( $metadata['pb_authors'] ) ? get_contributors_name_imploded( $metadata['pb_authors'] ) : $metadata['pb_authors'];
-			}
-
-			if ( isset( $metadata['pb_editors'] ) && ! empty( $metadata['pb_editors'] ) ) {
-				$editors = is_array( $metadata['pb_editors'] ) ? get_contributors_name_imploded( $metadata['pb_editors'] ) : $metadata['pb_editors'];
-				$editors = __( 'Edited By ', 'pressbooks' ) . $editors;
-			}
-
-			if ( isset( $metadata['pb_translators'] ) && ! empty( $metadata['pb_translators'] ) ) {
-				$translators = is_array( $metadata['pb_translators'] ) ? get_contributors_name_imploded( $metadata['pb_translators'] ) : $metadata['pb_translators'];
-				$translators = __( 'Translated By ', 'pressbooks' ) . $translators;
-
-			}
-
-			if ( isset( $metadata['pb_illustrators'] ) && ! empty( $metadata['pb_illustrators'] ) ) {
-				$illustrators = is_array( $metadata['pb_illustrators'] ) ? get_contributors_name_imploded( $metadata['pb_illustrators'] ) : $metadata['pb_illustrators'];
-				$illustrators = __( 'Illustrated By ', 'pressbooks' ) . $illustrators;
-			}
-
-			if ( isset( $metadata['pb_contributors'] ) && ! empty( $metadata['pb_contributors'] ) ) {
-				$contributors = is_array( $metadata['pb_contributors'] ) ? get_contributors_name_imploded( $metadata['pb_contributors'] ) : $metadata['pb_contributors'];
-				$contributors = __( 'Contributors: ', 'pressbooks' ) . $contributors;
-
-			}
+			$contributors_data = $this->getFormattedContributors( $metadata );
 
 			$html = $this->blade->render(
 				'export/title',
 				[
 					'title' => get_bloginfo( 'name' ),
 					'subtitle' => $metadata['pb_subtitle'] ?? '',
-					'authors' => $authors,
-					'editors' => $editors,
-					'translators' => $translators,
-					'illustrators' => $illustrators,
-					'contributors' => $contributors,
+					'authors' => $contributors_data['authors'],
+					'editors' => $contributors_data['editors'],
+					'translators' => $contributors_data['translators'],
+					'illustrators' => $contributors_data['illustrators'],
+					'contributors' => $contributors_data['contributors'],
 					'logo' => current_theme_supports( 'pressbooks_publisher_logo' ) ? get_theme_support( 'pressbooks_publisher_logo' )[0]['logo_uri'] : null,
 					'publisher' => $metadata['pb_publisher'] ?? '',
 					'publisher_city' => $metadata['pb_publisher_city'] ?? '',
@@ -2050,7 +2022,7 @@ class Epub extends ExportGenerator {
 
 		// Make sure empty tags (e.g. <b></b>) don't get turned into self-closing versions by adding an empty text node to them.
 		$xpath = new \DOMXPath( $dom );
-		while ( ( $nodes = $xpath->query( '//*[not(text() or node() or self::br or self::hr or self::img)]' ) ) && $nodes->length > 0 ) { // @codingStandardsIgnoreLine
+        while ( ( $nodes = $xpath->query( '//*[not(text() or node() or self::br or self::hr or self::img)]' ) ) && $nodes->length > 0 ) { // @codingStandardsIgnoreLine
 			foreach ( $nodes as $node ) {
 				/** @var \DOMElement $node */
 				$node->appendChild( new \DOMText( '' ) );
@@ -2184,7 +2156,7 @@ class Epub extends ExportGenerator {
 		if ( ! \Pressbooks\Image\is_valid_image( $tmp_file, $filename ) ) {
 			$this->fetchedImageCache[ $url ] = '';
 			debug_error_log( '\Pressbooks\Export\Epub\fetchAndSaveUniqueImage is_valid_image, not a valid image ' );
-			fclose( $GLOBALS[ $resource_key ] ); // @codingStandardsIgnoreLine
+            fclose( $GLOBALS[ $resource_key ] ); // @codingStandardsIgnoreLine
 			return ''; // Not an image
 		}
 
@@ -2215,7 +2187,7 @@ class Epub extends ExportGenerator {
 			$filename = wp_unique_filename( $fullpath, $filename );
 			copy( $tmp_file, "$fullpath/$filename" );
 		}
-		fclose( $GLOBALS[ $resource_key ] ); // @codingStandardsIgnoreLine
+        fclose( $GLOBALS[ $resource_key ] ); // @codingStandardsIgnoreLine
 
 		$this->fetchedImageCache[ $url ] = $filename;
 		return $filename;
@@ -2514,7 +2486,7 @@ class Epub extends ExportGenerator {
 				$val['post_name'] === $slug &&
 				$val['export']
 			) {
-				$found = array_merge( [ 'ID' => $post_id ], $val ); // @codingStandardsIgnoreLine
+                $found = array_merge( [ 'ID' => $post_id ], $val ); // @codingStandardsIgnoreLine
 			}
 		}
 		if ( empty( $found ) ) {

--- a/inc/modules/export/traits/class-handlecontributors.php
+++ b/inc/modules/export/traits/class-handlecontributors.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Pressbooks\Modules\Export\Traits;
+
+use function Pressbooks\Utility\get_contributors_name_imploded;
+
+/**
+ * Trait HandleContributors
+ * Common logic for formatting contributors for title pages in exports.
+ */
+trait HandleContributors {
+
+	/**
+	 * Get formatted contributor strings based on metadata.
+	 *
+	 * @param array $metadata Book metadata array.
+	 * @return array Associative array of formatted contributor strings.
+	 */
+	protected function getFormattedContributors( array $metadata ): array {
+		$contributors_data = [
+			'authors' => null,
+			'editors' => null,
+			'translators' => null,
+			'illustrators' => null,
+			'contributors' => null,
+		];
+
+		if ( isset( $metadata['pb_authors'] ) && ! empty( $metadata['pb_authors'] ) ) {
+			$contributors_data['authors'] = is_array( $metadata['pb_authors'] ) ? get_contributors_name_imploded( $metadata['pb_authors'] ) : $metadata['pb_authors'];
+		}
+
+		if ( isset( $metadata['pb_editors'] ) && ! empty( $metadata['pb_editors'] ) ) {
+			$editors_raw = is_array( $metadata['pb_editors'] ) ? get_contributors_name_imploded( $metadata['pb_editors'] ) : $metadata['pb_editors'];
+			$contributors_data['editors'] = __( 'Edited By ', 'pressbooks' ) . $editors_raw;
+		}
+
+		if ( isset( $metadata['pb_translators'] ) && ! empty( $metadata['pb_translators'] ) ) {
+			$translators_raw = is_array( $metadata['pb_translators'] ) ? get_contributors_name_imploded( $metadata['pb_translators'] ) : $metadata['pb_translators'];
+			$contributors_data['translators'] = __( 'Translated By ', 'pressbooks' ) . $translators_raw;
+		}
+
+		if ( isset( $metadata['pb_illustrators'] ) && ! empty( $metadata['pb_illustrators'] ) ) {
+			$illustrators_raw = is_array( $metadata['pb_illustrators'] ) ? get_contributors_name_imploded( $metadata['pb_illustrators'] ) : $metadata['pb_illustrators'];
+			$contributors_data['illustrators'] = __( 'Illustrated By ', 'pressbooks' ) . $illustrators_raw;
+		}
+
+		if ( isset( $metadata['pb_contributors'] ) && ! empty( $metadata['pb_contributors'] ) ) {
+			$contributors_raw = is_array( $metadata['pb_contributors'] ) ? get_contributors_name_imploded( $metadata['pb_contributors'] ) : $metadata['pb_contributors'];
+			$contributors_data['contributors'] = __( 'Contributors: ', 'pressbooks' ) . $contributors_raw;
+		}
+
+		return $contributors_data;
+	}
+}

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -16,7 +16,6 @@ use function Pressbooks\Modules\Export\get_contributors_section;
 use function Pressbooks\Sanitize\clean_filename;
 use function Pressbooks\Sanitize\decode;
 use function Pressbooks\Utility\check_xmllint_install;
-use function Pressbooks\Utility\get_contributors_name_imploded;
 use function Pressbooks\Utility\put_contents;
 use function Pressbooks\Utility\str_starts_with;
 use PressbooksMix\Assets;
@@ -29,6 +28,7 @@ use Pressbooks\Interactive\Content;
 use Pressbooks\Modules\Export\Export;
 use Pressbooks\Modules\Export\ExportGenerator;
 use Pressbooks\Modules\Export\ExportHelpers;
+use Pressbooks\Modules\Export\Traits\HandleContributors;
 use Pressbooks\Sanitize;
 use Pressbooks\Taxonomy;
 use Pressbooks\Utility\PercentageYield;
@@ -36,6 +36,7 @@ use Pressbooks\Utility\PercentageYield;
 class Xhtml11 extends ExportGenerator {
 
 	use ExportHelpers;
+	use HandleContributors;
 
 	const TRANSIENT = 'pressbooks_export_xhtml_buffer_inner_html';
 
@@ -733,7 +734,7 @@ class Xhtml11 extends ExportGenerator {
 		foreach ( $links as $link ) {
 			/**
 			 * @var \DOMElement $link
-			*/
+			 */
 			$href = $link->getAttribute( 'href' );
 
 			if ( str_starts_with( $href, '#' ) && ! empty( $id ) ) {
@@ -829,7 +830,7 @@ class Xhtml11 extends ExportGenerator {
 		foreach ( $images as $image ) {
 			/**
 			 * @var \DOMElement $image
-			*/
+			 */
 			$old_src = $image->getAttribute( 'src' );
 			$new_src = $already_done[ $old_src ] ?? maybe_swap_with_bigger( $old_src );
 			if ( $old_src !== $new_src ) {
@@ -1022,47 +1023,17 @@ class Xhtml11 extends ExportGenerator {
 				]
 			);
 		} else {
-			$authors = null;
-			$contributors = null;
-			$editors = null;
-			$translators = null;
-			$illustrators = null;
-
-			if ( isset( $metadata['pb_authors'] ) && ! empty( $metadata['pb_authors'] ) ) {
-				$authors = is_array( $metadata['pb_authors'] ) ? get_contributors_name_imploded( $metadata['pb_authors'] ) : $metadata['pb_authors'];
-			}
-
-			if ( isset( $metadata['pb_editors'] ) && ! empty( $metadata['pb_editors'] ) ) {
-				$editors = is_array( $metadata['pb_editors'] ) ? get_contributors_name_imploded( $metadata['pb_editors'] ) : $metadata['pb_editors'];
-				$editors = __( 'Edited By ', 'pressbooks' ) . $editors;
-			}
-
-			if ( isset( $metadata['pb_translators'] ) && ! empty( $metadata['pb_translators'] ) ) {
-				$translators = is_array( $metadata['pb_translators'] ) ? get_contributors_name_imploded( $metadata['pb_translators'] ) : $metadata['pb_translators'];
-				$translators = __( 'Translated By ', 'pressbooks' ) . $translators;
-
-			}
-
-			if ( isset( $metadata['pb_illustrators'] ) && ! empty( $metadata['pb_illustrators'] ) ) {
-				$illustrators = is_array( $metadata['pb_illustrators'] ) ? get_contributors_name_imploded( $metadata['pb_illustrators'] ) : $metadata['pb_illustrators'];
-				$illustrators = __( 'Illustrated By ', 'pressbooks' ) . $illustrators;
-			}
-
-			if ( isset( $metadata['pb_contributors'] ) && ! empty( $metadata['pb_contributors'] ) ) {
-				$contributors = is_array( $metadata['pb_contributors'] ) ? get_contributors_name_imploded( $metadata['pb_contributors'] ) : $metadata['pb_contributors'];
-				$contributors = __( 'Coontributors: ', 'pressbooks' ) . $contributors;
-
-			}
+			$contributors_data = $this->getFormattedContributors( $metadata );
 
 			echo $this->blade->render(
 				'export/title', [
 					'title' => get_bloginfo( 'name' ),
 					'subtitle' => $metadata['pb_subtitle'] ?? '',
-					'authors' => $authors,
-					'editors' => $editors,
-					'translators' => $translators,
-					'illustrators' => $illustrators,
-					'contributors' => $contributors,
+					'authors' => $contributors_data['authors'],
+					'editors' => $contributors_data['editors'],
+					'translators' => $contributors_data['translators'],
+					'illustrators' => $contributors_data['illustrators'],
+					'contributors' => $contributors_data['contributors'],
 					'logo' => current_theme_supports( 'pressbooks_publisher_logo' ) ? get_theme_support( 'pressbooks_publisher_logo' )[0]['logo_uri'] : null,
 					'publisher' => $metadata['pb_publisher'] ?? '',
 					'publisher_city' => $metadata['pb_publisher_city'] ?? '',
@@ -1467,8 +1438,8 @@ class Xhtml11 extends ExportGenerator {
 
 			if ( $parts_amount === 1 ) {
 				$content = $part_content
-				? $rendered_part . $rendered_chapters
-				: $rendered_chapters;
+					? $rendered_part . $rendered_chapters
+					: $rendered_chapters;
 
 				$this->renderPart( $part_slug, $content );
 			} else {

--- a/tests/test-exporthelpers.php
+++ b/tests/test-exporthelpers.php
@@ -1,6 +1,9 @@
 <?php
 
+use Pressbooks\Book;
+use Pressbooks\Contributors;
 use Pressbooks\Modules\Export\ExportHelpers;
+use Pressbooks\Taxonomy;
 
 class ExportHelpersTest extends \WP_UnitTestCase {
 	use ExportHelpers;
@@ -48,10 +51,10 @@ class ExportHelpersTest extends \WP_UnitTestCase {
 	 */
 	public function test_mapBookDataAndContentFrontMatter() {
 		$this->_book();
-		$metadata = \Pressbooks\Book::getBookInformation( null, false, false );
-		$book_contents = \Pressbooks\Book::getBookContents();
-		$this->taxonomy = \Pressbooks\Taxonomy::init();
-		$this->contributors = new \Pressbooks\Contributors();
+		$metadata = Book::getBookInformation( null, false, false );
+		$book_contents = Book::getBookContents();
+		$this->taxonomy = Taxonomy::init();
+		$this->contributors = new Contributors();
 
 		$front_matter_mapped = $this->mapBookDataAndContent(
 			$book_contents['front-matter'][0],
@@ -75,10 +78,10 @@ class ExportHelpersTest extends \WP_UnitTestCase {
 	 */
 	public function test_mapBookDataAndContentBackMatter() {
 		$this->_book();
-		$metadata = \Pressbooks\Book::getBookInformation( null, false, false );
-		$book_contents = \Pressbooks\Book::getBookContents();
-		$this->taxonomy = \Pressbooks\Taxonomy::init();
-		$this->contributors = new \Pressbooks\Contributors();
+		$metadata = Book::getBookInformation( null, false, false );
+		$book_contents = Book::getBookContents();
+		$this->taxonomy = Taxonomy::init();
+		$this->contributors = new Contributors();
 
 		$back_matter_mapped = $this->mapBookDataAndContent(
 			$book_contents['back-matter'][0],
@@ -118,4 +121,98 @@ class ExportHelpersTest extends \WP_UnitTestCase {
 		$xhtml = new \Pressbooks\Modules\Export\Xhtml\Xhtml11( [ ] );
 		return $xhtml->doFootnotes( $id );
 	}
+
+    /**
+     * @group export_helpers
+     */
+    public function test_renderTitle() {
+        $this->_book();
+        $metadata = Book::getBookInformation( null, false, false );
+        // Add contributor data to metadata
+        $metadata['pb_authors'] = 'Test Author';
+        $metadata['pb_editors'] = 'Test Editor';
+        $metadata['pb_translators'] = 'Test Translator';
+        $metadata['pb_illustrators'] = 'Test Illustrator';
+        $metadata['pb_contributors'] = 'Test Contributor';
+
+        $book_contents = Book::getBookContents();
+        $this->taxonomy = Taxonomy::init();
+        $this->contributors = new Contributors();
+
+        // Test XHTML11 renderTitle
+        $xhtml = new \Pressbooks\Modules\Export\Xhtml\Xhtml11( [] );
+        // Set the taxonomy property for Xhtml class
+        $xhtml_reflection_prop = new \ReflectionClass( $xhtml );
+        $xhtml_taxonomy_prop = $xhtml_reflection_prop->getProperty( 'taxonomy' );
+        $xhtml_taxonomy_prop->setAccessible( true );
+        $xhtml_taxonomy_prop->setValue( $xhtml, $this->taxonomy );
+
+        ob_start();
+        $xhtml_reflection = new \ReflectionClass( $xhtml );
+        $xhtml_method = $xhtml_reflection->getMethod( 'renderTitle' );
+        $xhtml_method->setAccessible( true );
+        $xhtml_method->invokeArgs( $xhtml, [ $book_contents, $metadata ] );
+        $xhtml_output = ob_get_clean();
+
+        // Basic assertions for XHTML output - adjust as needed
+        $this->assertStringContainsString( '<div id="title-page"',
+            $xhtml_output );
+        $this->assertStringContainsString( get_bloginfo( 'name' ), $xhtml_output ); // Check if book title exists
+        // Check for contributors
+        $this->assertStringContainsString( 'Test Author', $xhtml_output );
+        $this->assertStringContainsString( __( 'Edited By ', 'pressbooks' ) . 'Test Editor', $xhtml_output );
+        $this->assertStringContainsString( __( 'Translated By ', 'pressbooks' ) . 'Test Translator', $xhtml_output );
+        $this->assertStringContainsString( __( 'Illustrated By ', 'pressbooks' ) . 'Test Illustrator', $xhtml_output );
+        $this->assertStringContainsString( __( 'Contributors: ', 'pressbooks' ) . 'Test Contributor', $xhtml_output );
+
+        // Test Epub renderTitle
+        $epub = new \Pressbooks\Modules\Export\Epub\Epub( [] );
+        $epub_reflection = new \ReflectionClass( $epub );
+        $epub_method = $epub_reflection->getMethod( 'renderTitle' );
+        $epub_method->setAccessible( true );
+
+        // Epub renderTitle modifies the manifest and creates files, it doesn't echo directly.
+        // We need to check the side effects, like file creation and manifest update.
+        // Let's mock createEpubFile and updateManifest to verify they are called correctly.
+        $mock_epub = $this->getMockBuilder( \Pressbooks\Modules\Export\Epub\Epub::class )
+            ->setConstructorArgs( [[]] )
+            ->onlyMethods( [ 'createEpubFile', 'updateManifest' ] )
+            ->getMock();
+
+        $mock_epub->expects( $this->once() )
+            ->method( 'createEpubFile' )
+            ->with(
+                $this->equalTo( 'title-page.xhtml' ), // Assuming default extension
+                // Check that the data array contains expected contributor info in its rendered content
+                $this->callback(function($data) {
+                    $this->assertArrayHasKey('post_content', $data);
+                    $this->assertStringContainsString('Test Author', $data['post_content']);
+                    $this->assertStringContainsString(__( 'Edited By ', 'pressbooks' ) . 'Test Editor', $data['post_content']);
+                    $this->assertStringContainsString(__( 'Translated By ', 'pressbooks' ) . 'Test Translator', $data['post_content']);
+                    $this->assertStringContainsString(__( 'Illustrated By ', 'pressbooks' ) . 'Test Illustrator', $data['post_content']);
+                    $this->assertStringContainsString(__( 'Contributors: ', 'pressbooks' ) . 'Test Contributor', $data['post_content']);
+                    return true; // Return true if all assertions pass
+                })
+            );
+
+        $mock_epub->expects( $this->once() )
+            ->method( 'updateManifest' )
+            ->with(
+                $this->equalTo( 'title-page' ),
+                $this->arrayHasKey( 'filename' )
+            );
+
+        // Need to set the taxonomy property for Epub class as well
+        $epub_taxonomy_prop = $epub_reflection->getProperty( 'taxonomy' );
+        $epub_taxonomy_prop->setAccessible( true );
+        $epub_taxonomy_prop->setValue( $mock_epub, $this->taxonomy );
+
+        // Invoke the method on the mock object
+        $epub_method->invokeArgs( $mock_epub, [ $book_contents, $metadata ] );
+
+        // Since invokeArgs doesn't return a value for protected methods called on mocks,
+        // the assertions are handled by the mock expectations above.
+        // We can add a dummy assertion to prevent PHPUnit risky test warning
+        $this->assertTrue( true );
+    }
 }

--- a/tests/test-exporthelpers.php
+++ b/tests/test-exporthelpers.php
@@ -215,4 +215,86 @@ class ExportHelpersTest extends \WP_UnitTestCase {
         // We can add a dummy assertion to prevent PHPUnit risky test warning
         $this->assertTrue( true );
     }
+
+    /**
+     * @group export_helpers
+     */
+    public function test_renderTitle_with_multiple_contributors() {
+        $this->_book();
+        $metadata = Book::getBookInformation( null, false, false );
+        // Add multiple contributor data to metadata as array of arrays with 'name' key
+        $metadata['pb_authors'] = [['name' => 'Test Author 1'], ['name' => 'Test Author 2']];
+        $metadata['pb_editors'] = [['name' => 'Test Editor 1'], ['name' => 'Test Editor 2']];
+        $metadata['pb_translators'] = [['name' => 'Test Translator 1'], ['name' => 'Test Translator 2']];
+        $metadata['pb_illustrators'] = [['name' => 'Test Illustrator 1'], ['name' => 'Test Illustrator 2']];
+        $metadata['pb_contributors'] = [['name' => 'Test Contributor 1'], ['name' => 'Test Contributor 2']];
+
+        $book_contents = Book::getBookContents();
+        $this->taxonomy = Taxonomy::init();
+        $this->contributors = new Contributors();
+
+        // --- Test XHTML11 renderTitle (Multiple Contributors) ---
+        $xhtml = new \Pressbooks\Modules\Export\Xhtml\Xhtml11( [] );
+        $xhtml_reflection_prop = new \ReflectionClass( $xhtml );
+        $xhtml_taxonomy_prop = $xhtml_reflection_prop->getProperty( 'taxonomy' );
+        $xhtml_taxonomy_prop->setAccessible( true );
+        $xhtml_taxonomy_prop->setValue( $xhtml, $this->taxonomy );
+
+        ob_start();
+        $xhtml_reflection = new \ReflectionClass( $xhtml );
+        $xhtml_method = $xhtml_reflection->getMethod( 'renderTitle' );
+        $xhtml_method->setAccessible( true );
+        $xhtml_method->invokeArgs( $xhtml, [ $book_contents, $metadata ] );
+        $xhtml_output = ob_get_clean();
+
+        // Assertions for XHTML output (Multiple Contributors) - Expecting ' and ' separation
+        $this->assertStringContainsString( '<div id="title-page"', $xhtml_output );
+        $this->assertStringContainsString( get_bloginfo( 'name' ), $xhtml_output );
+        $this->assertStringContainsString( 'Test Author 1 and Test Author 2', $xhtml_output );
+        $this->assertStringContainsString( __( 'Edited By ', 'pressbooks' ) . 'Test Editor 1 and Test Editor 2', $xhtml_output );
+        $this->assertStringContainsString( __( 'Translated By ', 'pressbooks' ) . 'Test Translator 1 and Test Translator 2', $xhtml_output );
+        $this->assertStringContainsString( __( 'Illustrated By ', 'pressbooks' ) . 'Test Illustrator 1 and Test Illustrator 2', $xhtml_output );
+        $this->assertStringContainsString( __( 'Contributors: ', 'pressbooks' ) . 'Test Contributor 1 and Test Contributor 2', $xhtml_output );
+
+        // --- Test Epub renderTitle (Multiple Contributors) ---
+        $epub_reflection = new \ReflectionClass( '\Pressbooks\Modules\Export\Epub\Epub' );
+        $epub_method = $epub_reflection->getMethod( 'renderTitle' );
+        $epub_method->setAccessible( true );
+        $epub_taxonomy_prop = $epub_reflection->getProperty( 'taxonomy' );
+        $epub_taxonomy_prop->setAccessible( true );
+
+        $mock_epub = $this->getMockBuilder( \Pressbooks\Modules\Export\Epub\Epub::class )
+            ->setConstructorArgs( [[]] )
+            ->onlyMethods( [ 'createEpubFile', 'updateManifest' ] )
+            ->getMock();
+
+        $mock_epub->expects( $this->once() )
+            ->method( 'createEpubFile' )
+            ->with(
+                $this->equalTo( 'title-page.xhtml' ),
+                // Check that the data array contains expected multiple contributor info (names separated by ' and ')
+                $this->callback(function($data) {
+                    $this->assertArrayHasKey('post_content', $data);
+                    $this->assertStringContainsString('Test Author 1 and Test Author 2', $data['post_content']);
+                    $this->assertStringContainsString(__( 'Edited By ', 'pressbooks' ) . 'Test Editor 1 and Test Editor 2', $data['post_content']);
+                    $this->assertStringContainsString(__( 'Translated By ', 'pressbooks' ) . 'Test Translator 1 and Test Translator 2', $data['post_content']);
+                    $this->assertStringContainsString(__( 'Illustrated By ', 'pressbooks' ) . 'Test Illustrator 1 and Test Illustrator 2', $data['post_content']);
+                    $this->assertStringContainsString(__( 'Contributors: ', 'pressbooks' ) . 'Test Contributor 1 and Test Contributor 2', $data['post_content']);
+                    return true; // Return true if all assertions pass
+                })
+            );
+
+        $mock_epub->expects( $this->once() )
+            ->method( 'updateManifest' )
+            ->with(
+                $this->equalTo( 'title-page' ),
+                $this->arrayHasKey( 'filename' )
+            );
+
+        $epub_taxonomy_prop->setValue( $mock_epub, $this->taxonomy );
+        $epub_method->invokeArgs( $mock_epub, [ $book_contents, $metadata ] );
+
+        // Add a final dummy assertion if needed to prevent risky test warnings, though the mock expectations should cover it.
+        $this->assertTrue( true );
+    }
 }


### PR DESCRIPTION
This pull request introduces a new `HandleContributors` trait to centralize and simplify the logic for handling contributor metadata across different export formats. The changes improve code maintainability and add comprehensive unit tests for contributor-related functionality.

### Code Refactoring and Simplification:
* Introduced the `HandleContributors` trait to encapsulate logic for formatting contributor metadata (`authors`, `editors`, `translators`, `illustrators`, and `contributors`) into a reusable method `getFormattedContributors`. This reduces redundancy and improves maintainability. 

* Updated the `Epub` and `Xhtml11` export classes to use the `HandleContributors` trait, replacing inline contributor formatting logic with calls to `getFormattedContributors`. 

### Unit Testing Enhancements:
* Added new unit tests to validate the `renderTitle` method for both `Epub` and `Xhtml11` exports. These tests cover scenarios with single and multiple contributors, ensuring proper formatting and rendering of contributor data.

### Code Cleanup:
* Removed redundant `get_contributors_name_imploded` function calls from the `Xhtml11` export class, as this logic is now encapsulated in the `HandleContributors` trait. 

* Updated test cases in `ExportHelpersTest` to use simplified imports for `Book`, `Contributors`, and `Taxonomy` classes, improving code readability. 